### PR TITLE
修复仓库更新失败 重复添加定时问题。

### DIFF
--- a/shell/update.sh
+++ b/shell/update.sh
@@ -171,11 +171,10 @@ update_repo() {
     fi
     if [[ $exit_status -eq 0 ]]; then
         echo -e "\n更新${repo_path}成功...\n"
+        diff_scripts $repo_path $author $path $blackword $dependence
     else
         echo -e "\n更新${repo_path}失败，请检查原因...\n"
     fi
-
-    diff_scripts $repo_path $author $path $blackword $dependence
 }
 
 ## 更新所有 raw 文件


### PR DESCRIPTION
仓库更新失败时，没找到对应仓库目录，会把其他仓库的脚本添加前缀重复添加到定时。