### PR TITLE
Add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./data/log:/ql/log
       - ./data/db:/ql/db
       - ./data/scripts:/ql/scripts
-      - ./data/jbot:/ql/jbot
       - ./data/repo:/ql/repo
     ports:
       - "0.0.0.0:5700:5700"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+  web:
+    image: whyour/qinglong:latest
+    volumes:
+      - ./data/config:/ql/config
+      - ./data/log:/ql/log
+      - ./data/db:/ql/db
+      - ./data/scripts:/ql/scripts
+      - ./data/jbot:/ql/jbot
+      - ./data/repo:/ql/repo
+    ports:
+      - "0.0.0.0:5700:5700"
+    environment:
+      - ENABLE_HANGUP=true
+      - ENABLE_WEB_PANEL=true
+    restart: always


### PR DESCRIPTION
添加了`docker-compose.yml`文件，方便使用docker-compose一键启动
默认情况下所有的数据都保存在`docker-compose.yml`文件所在的相同目录下的`data`文件夹
使用方式，以Debian举例，其它系统参考，需要预先安装好`docker-ce`和`docker-compose`
```bash
root@debian:/opt/# mkdir qinglong && cd qinglong
root@debian:/opt/qinglong# wget https://cdn.jsdelivr.net/gh/whyour/qinglong@develop/docker-compose.yml
root@debian:/opt/qinglong# docker-compose up -d
```
之后打开浏览器访问5700端口即可。第一次账号密码均输入`admin`，会生成`auth.json`，运行如下命令可查看具体的密码
```bash
root@debian:/opt/qinglong# cat data/config/auth.json
{"username":"admin","password":"Xb-ZYP526wmg4_h6q1WqIO"}
```
登陆后即可正常使用