### PR TITLE
fix: 移除dockerfile中上次pr时新增的三个不必要的环境变量，避免与其他库的含义产生冲突，如导致ninja无法正常访问青龙api

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,13 @@
 FROM node:lts-alpine
 ARG QL_MAINTAINER="whyour"
 LABEL maintainer="${QL_MAINTAINER}"
-ARG QL_URL=http://localhost:5600
-ARG QL_REPOSITORY_URL=https://github.com/${QL_MAINTAINER}/qinglong.git
+ARG QL_URL=https://github.com/${QL_MAINTAINER}/qinglong.git
 ARG QL_BRANCH=master
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     LANG=zh_CN.UTF-8 \
     SHELL=/bin/bash \
     PS1="\u@\h:\w \$ " \
-    QL_DIR=/ql \
-    QL_URL=${QL_URL} \
-    QL_MAINTAINER=${QL_MAINTAINER} \
-    QL_REPOSITORY_URL=${QL_REPOSITORY_URL} \
-    QL_BRANCH=${QL_BRANCH}
+    QL_DIR=/ql
 WORKDIR ${QL_DIR}
 RUN set -x \
     && sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories \
@@ -36,7 +31,7 @@ RUN set -x \
     && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone \
     && touch ~/.bashrc \
-    && git clone -b ${QL_BRANCH} ${QL_REPOSITORY_URL} ${QL_DIR} \
+    && git clone -b ${QL_BRANCH} ${QL_URL} ${QL_DIR} \
     && git config --global user.email "qinglong@@users.noreply.github.com" \
     && git config --global user.name "qinglong" \
     && cd ${QL_DIR} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,15 +1,17 @@
 FROM node:lts-alpine
 ARG QL_MAINTAINER="whyour"
 LABEL maintainer="${QL_MAINTAINER}"
-ARG QL_URL=https://github.com/${QL_MAINTAINER}/qinglong.git
+ARG QL_URL=http://localhost:5600
+ARG QL_GITHUB_URL=https://github.com/${QL_MAINTAINER}/qinglong.git
 ARG QL_BRANCH=master
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     LANG=zh_CN.UTF-8 \
     SHELL=/bin/bash \
     PS1="\u@\h:\w \$ " \
     QL_DIR=/ql \
-    QL_MAINTAINER=${QL_MAINTAINER} \
     QL_URL=${QL_URL} \
+    QL_MAINTAINER=${QL_MAINTAINER} \
+    QL_GITHUB_URL=${QL_GITHUB_URL} \
     QL_BRANCH=${QL_BRANCH}
 WORKDIR ${QL_DIR}
 RUN set -x \
@@ -34,7 +36,7 @@ RUN set -x \
     && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone \
     && touch ~/.bashrc \
-    && git clone -b ${QL_BRANCH} ${QL_URL} ${QL_DIR} \
+    && git clone -b ${QL_BRANCH} ${QL_GITHUB_URL} ${QL_DIR} \
     && git config --global user.email "qinglong@@users.noreply.github.com" \
     && git config --global user.name "qinglong" \
     && cd ${QL_DIR} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,8 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     LANG=zh_CN.UTF-8 \
     SHELL=/bin/bash \
     PS1="\u@\h:\w \$ " \
-    QL_DIR=/ql
+    QL_DIR=/ql \
+    QL_BRANCH=${QL_BRANCH}
 WORKDIR ${QL_DIR}
 RUN set -x \
     && sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:lts-alpine
 ARG QL_MAINTAINER="whyour"
 LABEL maintainer="${QL_MAINTAINER}"
 ARG QL_URL=http://localhost:5600
-ARG QL_GITHUB_URL=https://github.com/${QL_MAINTAINER}/qinglong.git
+ARG QL_REPOSITORY_URL=https://github.com/${QL_MAINTAINER}/qinglong.git
 ARG QL_BRANCH=master
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     LANG=zh_CN.UTF-8 \
@@ -11,7 +11,7 @@ ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     QL_DIR=/ql \
     QL_URL=${QL_URL} \
     QL_MAINTAINER=${QL_MAINTAINER} \
-    QL_GITHUB_URL=${QL_GITHUB_URL} \
+    QL_REPOSITORY_URL=${QL_REPOSITORY_URL} \
     QL_BRANCH=${QL_BRANCH}
 WORKDIR ${QL_DIR}
 RUN set -x \
@@ -36,7 +36,7 @@ RUN set -x \
     && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone \
     && touch ~/.bashrc \
-    && git clone -b ${QL_BRANCH} ${QL_GITHUB_URL} ${QL_DIR} \
+    && git clone -b ${QL_BRANCH} ${QL_REPOSITORY_URL} ${QL_DIR} \
     && git config --global user.email "qinglong@@users.noreply.github.com" \
     && git config --global user.name "qinglong" \
     && cd ${QL_DIR} \


### PR DESCRIPTION
# 问题描述
上次pr新增了QL_URL等环境变量，会导致ninja库中误读该变量而无法正常工作

## 青龙
上次pr时定义了一个变量QL_URL，用作后续拉取青龙仓库。
https://github.com/whyour/qinglong/blob/cc098bc2e503ae3a55028b9a14ae07c1c472923d/docker/Dockerfile#L4
https://github.com/whyour/qinglong/blob/cc098bc2e503ae3a55028b9a14ae07c1c472923d/docker/Dockerfile#L37

## ninja
而在ninji（目前只剩下手动录入ck的作用）中，在获取青龙的api地址时，会尝试从环境变量中获取process.env.QL_URL的值，因为此环境变量在上述dockerfile中设置为了仓库链接，这里后续逻辑就会出错。导致使用的人，可能会觉得很奇怪，怎么突然不好使了。
https://github.com/MoonBegonia/ninja/blob/a5c13ea26f4bfb49c88e7b1ec0f761b96f44bfe3/backend/ql.js#L11-L14
```js
const api = got.extend({
  prefixUrl: process.env.QL_URL || 'http://localhost:5600',
  retry: { limit: 0 },
});
```

# 解决方式
移除多余的环境变量