### PR TITLE
feat: 在antd的Table组件的默认分页大小选项基础上添加更多选项，方便在脚本超过100的情况下，想选择全部脚本时，不用再额外翻页

### DIFF
--- a/src/pages/crontab/index.tsx
+++ b/src/pages/crontab/index.tsx
@@ -866,6 +866,7 @@ const Crontab = ({ headerStyle, isPhone }: any) => {
           defaultPageSize: 20,
           showTotal: (total: number, range: number[]) =>
             `第 ${range[0]}-${range[1]} 条/总共 ${total} 条`,
+          pageSizeOptions: [10, 20, 50, 100, 200, 500, 1000],
         }}
         dataSource={value}
         rowKey="_id"


### PR DESCRIPTION
在antd的table默认配置中，分页大小选项为 [10/20/50/100](https://ant.design/components/pagination/#API) ，因此在脚本数超过一百的时候，如果想要全部选中，就必须要依次进行以下操作
1. 修改下方页面大小为100
2. 点左上角全选
3. 切换下一页
4. 再点一次左上角的全选

如果把该选项增加几个更大的值，以上步骤就可以简化为
1. 修改下方页面大小为200/500/1000之一
2. 点左上角全选

![image](https://user-images.githubusercontent.com/13483212/142726143-70dd1aa8-0307-4047-9a2c-797bf4f5adaf.png)

