### PR TITLE
Update notify.js

### DIFF
--- a/sample/notify.js
+++ b/sample/notify.js
@@ -203,6 +203,12 @@ async function sendNotify(
 ) {
   //提供6种通知
   desp += author; //增加作者信息，防止被贩卖等
+  if(desp.length>900) {
+    await sendNotify(text, desp.substr(0,900),params,"\n\n==More==");
+    await sendNotify(text, desp.substr(900),params,author);
+    return;
+  }
+    
   await Promise.all([
     serverNotify(text, desp), //微信server酱
     pushPlusNotify(text, desp), //pushplus(推送加)


### PR DESCRIPTION
消息过长进行分段发送。
企业微信一条消息大约1024个，超过长度的会被截断舍弃。
将消息按照900字符分段显示，再长的消息也能完整显示。