### PR TITLE
修复goCqHttpBotToken中存在&字符导致认证失败的问题

### DIFF
--- a/back/services/notify.ts
+++ b/back/services/notify.ts
@@ -91,11 +91,12 @@ export default class NotificationService {
     const { goCqHttpBotQq, goCqHttpBotToken, goCqHttpBotUrl } = this.params;
     const res: any = await got
       .post(
-        `${goCqHttpBotUrl}?access_token=${goCqHttpBotToken}&${goCqHttpBotQq}`,
+        `${goCqHttpBotUrl}?${goCqHttpBotQq}`,
         {
           timeout: this.timeout,
           retry: 0,
           json: { message: `${this.title}\n${this.content}` },
+          headers: { 'Authorization': 'Bearer '+goCqHttpBotToken },
         },
       )
       .json();


### PR DESCRIPTION
修改goCqHttpBot鉴权方式，调整为使用Header模式，此处回调函数可使用[send_msg 发送消息](https://github.com/botuniverse/onebot-11/blob/master/api/public.md#send_msg-%E5%8F%91%E9%80%81%E6%B6%88%E6%81%AF)API来实现更为优雅的前端配置方式，但考虑到需要同时修改前后端，暂不提交