### PR TITLE
不再检测是否为termux

### DIFF
--- a/shell/share.sh
+++ b/shell/share.sh
@@ -102,7 +102,7 @@ make_dir() {
 
 detect_termux() {
     if [[ ${ANDROID_RUNTIME_ROOT}${ANDROID_ROOT} ]] || [[ $PATH == *com.termux* ]]; then
-        is_termux=1
+        is_termux=0
     else
         is_termux=0
     fi


### PR DESCRIPTION
保留此处代码，只将检测结果设为0（非termux）。
因为检测termux好像用处不大，原生termux安装青龙几乎没有应用场景，且**termux可以直接安装Linux发行版避免此处考虑到的各种问题**。