### PR TITLE
区分原生termux和termux中安装的Linux发行版

### DIFF
--- a/shell/share.sh
+++ b/shell/share.sh
@@ -99,7 +99,7 @@ make_dir() {
 }
 
 detect_termux() {
-    if [[ ${ANDROID_RUNTIME_ROOT}${ANDROID_ROOT} ]] || [[ $PATH == *com.termux* ]]; then
+    if [[ $PATH == *com.termux* ]]; then
         is_termux=1
     else
         is_termux=0


### PR DESCRIPTION
termux中安装的Linux发行版应该作为普通Linux对待，不用当做termux而设置软连接什么的

测试发现${ANDROID_RUNTIME_ROOT}${ANDROID_ROOT}在termux中安装的Linux发行版中仍旧存在，PATH则不再有com.termux。
所以可以在检测termux时只检查环境变量是否有com.termux，或者检查/data/data/com.termux/files/目录是否存在，以此区分原生termux和termux中安装的Linux发行版
