### PR TITLE
修复非JS任务不能随机延迟的问题

### DIFF
--- a/back/services/cron.ts
+++ b/back/services/cron.ts
@@ -279,7 +279,11 @@ export default class CronService {
       if (!cmdStr.includes('task ') && !cmdStr.includes('ql ')) {
         cmdStr = `task ${cmdStr}`;
       }
-      if (cmdStr.endsWith('.js')) {
+      if (cmdStr.endsWith('.js') 
+        || cmdStr.endsWith('.py')
+        || cmdStr.endsWith('.pyc')
+        || cmdStr.endsWith('.sh')
+        || cmdStr.endsWith('.ts')) {
         cmdStr = `${cmdStr} now`;
       }
 

--- a/sample/config.sample.sh
+++ b/sample/config.sample.sh
@@ -29,6 +29,14 @@ MaxConcurrentNum="5"
 ## 默认给javascript任务加随机延迟，如 RandomDelay="300" ，表示任务将在 1-300 秒内随机延迟一个秒数，然后再运行，取消延迟赋值为空
 RandomDelay="300"
 
+## 需要随机延迟运行任务的文件后缀，直接写后缀名即可，多个后缀用空格分开，例如: js py ts
+## 默认仅给javascript任务加随机延迟，其它任务按定时规则准点运行。全部任务随机延迟赋值为空
+RandomDelayFileExtensions="js"
+
+## 每小时的第几分钟准点运行任务，当在这些时间运行任务时将忽略 RandomDelay 配置，不会被随机延迟
+## 默认是第0分钟和第30分钟，例如21:00或21:30分的任务将会准点运行。不需要准点运行赋值为空
+RandomDelayIgnoredMinutes="0 30"
+
 ## 如果你自己会写shell脚本，并且希望在每次运行 ql update 命令时，额外运行你的 shell 脚本，请赋值为 "true"，默认为true
 EnableExtraShell="true"
 

--- a/shell/task.sh
+++ b/shell/task.sh
@@ -24,12 +24,29 @@ define_program() {
 random_delay() {
     local random_delay_max=$RandomDelay
     if [[ $random_delay_max ]] && [[ $random_delay_max -gt 0 ]]; then
-        local current_min=$(date "+%-M")
-        if [[ $current_min -ne 0 ]] && [[ $current_min -ne 30 ]]; then
-            delay_second=$(($(gen_random_num $random_delay_max) + 1))
-            echo -e "\n命令未添加 \"now\"，随机延迟 $delay_second 秒后再执行任务，如需立即终止，请按 CTRL+C...\n"
-            sleep $delay_second
+        local file_param=$1
+        local file_extensions=${RandomDelayFileExtensions-"js"}
+        local ignored_minutes=${RandomDelayIgnoredMinutes-"0 30"}
+
+        if [[ -n $file_extensions ]]; then
+            if ! echo "$file_param" | grep -qE "\.${file_extensions// /$|\\.}$"; then
+                # echo -e "\n当前文件需要准点运行, 放弃随机延迟\n"
+                return
+            fi
         fi
+
+        local current_min
+        current_min=$(date "+%-M")
+        for minute in $ignored_minutes; do
+            if [[ $current_min -eq $minute ]]; then
+                # echo -e "\n当前时间需要准点运行, 放弃随机延迟\n"
+                return
+            fi
+        done
+
+        local delay_second=$(($(gen_random_num "$random_delay_max") + 1))
+        echo -e "\n命令未添加 \"now\"，随机延迟 $delay_second 秒后再执行任务，如需立即终止，请按 CTRL+C...\n"
+        sleep $delay_second
     fi
 }
 
@@ -78,10 +95,8 @@ run_nohup() {
 run_normal() {
     local file_param=$1
     define_program "$file_param"
-    if [[ $file_param == *.js ]]; then
-        if [[ $# -eq 1 ]]; then
-            random_delay
-        fi
+    if [[ $# -eq 1 ]]; then
+        random_delay "$file_param"
     fi
 
     local time=$(date "+$time_format")

--- a/shell/task.sh
+++ b/shell/task.sh
@@ -371,7 +371,7 @@ main() {
     fi
 
     time_format="%Y-%m-%d %H:%M:%S"
-    if [[ $1 == *.js ]] || [[ $1 == *.py ]] || [[ $1 == *.sh ]] || [[ $1 == *.ts ]]; then
+    if [[ $1 == *.js ]] || [[ $1 == *.py ]] || [[ $1 == *.pyc ]] || [[ $1 == *.sh ]] || [[ $1 == *.ts ]]; then
         case $# in
         1)
             run_normal "$1"


### PR DESCRIPTION
原代码写死了只有javascript的任务才能随机延迟
为此我添加了两项新配置用于设定哪些文件需要延迟、哪些时间需要准点。