### PR TITLE
修复视图的一些小问题

### DIFF
--- a/back/api/cron.ts
+++ b/back/api/cron.ts
@@ -28,7 +28,7 @@ export default (app: Router) => {
     celebrate({
       body: Joi.object({
         name: Joi.string().required(),
-        sorts: Joi.array().optional(),
+        sorts: Joi.array().optional().allow(null),
         filters: Joi.array().optional(),
       }),
     }),
@@ -49,7 +49,7 @@ export default (app: Router) => {
       body: Joi.object({
         name: Joi.string().required(),
         id: Joi.number().required(),
-        sorts: Joi.array().optional(),
+        sorts: Joi.array().optional().allow(null),
         filters: Joi.array().optional(),
       }),
     }),

--- a/back/services/cron.ts
+++ b/back/services/cron.ts
@@ -121,13 +121,16 @@ export default class CronService {
       for (const col of viewQuery.filters) {
         const { property, value, operation } = col;
         let q: any = {};
+        let operate2 = null;
         let operate = null;
         switch (operation) {
           case 'Reg':
             operate = Op.like;
+            operate2 = Op.or;
             break;
           case 'NotReg':
             operate = Op.notLike;
+            operate2 = Op.and;
             break;
           case 'In':
             q[Op.or] = [
@@ -154,9 +157,9 @@ export default class CronService {
           default:
             break;
         }
-        if (operate) {
+        if (operate && operate2) {
           q[property] = {
-            [Op.or]: [
+            [operate2]: [
               { [operate]: `%${value}%` },
               { [operate]: `%${encodeURIComponent(value)}%` },
             ],

--- a/src/pages/crontab/viewManageModal.tsx
+++ b/src/pages/crontab/viewManageModal.tsx
@@ -231,7 +231,10 @@ const ViewManageModal = ({
         <Button
           key="2"
           type="primary"
-          onClick={() => setIsCreateViewModalVisible(true)}
+          onClick={() => {
+            setEditedView(null);
+            setIsCreateViewModalVisible(true);
+          }}
         >
           新建视图
         </Button>

--- a/src/pages/crontab/viewManageModal.tsx
+++ b/src/pages/crontab/viewManageModal.tsx
@@ -261,8 +261,8 @@ const ViewManageModal = ({
         view={editedView}
         visible={isCreateViewModalVisible}
         handleCancel={(data) => {
-          cronViewChange(data);
           setIsCreateViewModalVisible(false);
+          cronViewChange(data);
         }}
       />
     </Modal>


### PR DESCRIPTION
1. 修复了视图无排序时无法再次修改的问题
>重现步骤：添加视图，设置名字和过滤，不添加排序，点击确定后再次编辑点击确定会报'sorts'不是数组的错误
修复方法：后端允许sorts键值为null
2. 修复了在视图管理中无法新建视图的问题
>重现步骤：打开视图管理，编辑视图，关闭，然后在管理视图中新建视图，此时会错误的显示上一次的编辑视图。
修复方法：前端新建时置空上一次的编辑视图，避免误判
3. 修复了在视图管理中新建、编辑视图后不能正确关闭视图页面的问题
>重现步骤：打开视图管理，编辑或新建视图，点击确定，此时页面没有自动隐藏
修复方法：在点击确定提交后，前端先隐藏页面再刷新视图数据
4. 修复了#1611 
避免查询条件被覆盖
>修复方法：把查询条件全部用逻辑与拼起来
5. 修复了搜索不受视图约束的问题
>修复方法：同上
6. 修复了**不包含**的条件中如果含有空格等特殊符号时不能正确排除的问题
>重现步骤：新增筛选条件 定时规则 不包含 1 1 但结果还是会有1 1 定时规则的任务
>修复方法：由于含有空格等特殊符号，判断时需要同时满足不包含原文和编码后的内容两个条件才行