### PR TITLE
修复#1614 正确解析多级目录的脚本路径

### DIFF
--- a/src/pages/crontab/detail.tsx
+++ b/src/pages/crontab/detail.tsx
@@ -153,9 +153,13 @@ const CronDetailModal = ({
         cmd[1] = cmd[1].replace('/ql/data/scripts/', '');
       }
 
-      let [p, s] = cmd[1].split('/');
-      if (!s) {
-        s = p;
+      let p: string, s: string;
+      let index = cmd[1].lastIndexOf('/');
+      if (index >= 0) {
+        s = cmd[1].slice(index + 1);
+        p = cmd[1].slice(0, index);
+      } else {
+        s = cmd[1];
         p = '';
       }
       setScriptInfo({ parent: p, filename: s });


### PR DESCRIPTION
原代码假定了脚本不会有超过一级的目录（不清楚其它地方还有没有类似的行为，最好也一并修改了）
我调整为以最后一个‘/’作为分割点，左侧脚本路径，右侧脚本文件名。

closes #1614