### PR TITLE
修复 可执行文件 提示找不到文件的问题

### DIFF
--- a/shell/otask.sh
+++ b/shell/otask.sh
@@ -193,7 +193,7 @@ run_else() {
   local relative_path="${file_param%/*}"
   if [[ ! -z ${relative_path} ]] && [[ ${file_param} =~ "/" ]]; then
     cd ${relative_path}
-    file_param=${file_param/$relative_path\//}
+    file_param=${file_param/$relative_path\//.\/}
   fi
 
   shift


### PR DESCRIPTION
运行可执行文件需要加路径: ./cmd