### PR TITLE
fix: consig配置WEBHOOK_BODY时换行符被转义无法正确分隔参数的问题

### DIFF
--- a/sample/notify.js
+++ b/sample/notify.js
@@ -1284,7 +1284,8 @@ function webhookNotify(text, desp) {
       return;
     }
     const headers = parseHeaders(WEBHOOK_HEADERS);
-    const body = parseBody(formatBody, WEBHOOK_CONTENT_TYPE);
+    const formatBodyChar = formatBody.replace(/\\n/g, '\n');
+    const body = parseBody(formatBodyChar, WEBHOOK_CONTENT_TYPE);
     const bodyParam = formatBodyFun(WEBHOOK_CONTENT_TYPE, body);
     const options = {
       method: WEBHOOK_METHOD,


### PR DESCRIPTION

export WEBHOOK_URL="http://test" 
export WEBHOOK_HEADERS=""
export WEBHOOK_BODY='title:$title \n text:$content'
export WEBHOOK_METHOD="POST"
export WEBHOOK_CONTENT_TYPE="application/json"
比如配置如上config.sh推送。WEBHOOK_BODY在js中已经被转义为\\r 此时parseBody函数并不能正确分割参数，需要在解析分割参数前进行替换转义字符