### PR TITLE
feat(sample/notify.py)：自定义参数

### DIFF
--- a/sample/notify.py
+++ b/sample/notify.py
@@ -419,16 +419,22 @@ def pushplus_bot(title: str, content: str, **kwargs) -> None:
             print("PUSHPLUS 推送失败！")
 
 
-def qmsg_bot(title: str, content: str) -> None:
+def qmsg_bot(title: str, content: str, **kwargs) -> None:
     """
     使用 qmsg 推送消息。
     """
-    if not push_config.get("QMSG_KEY") or not push_config.get("QMSG_TYPE"):
+    if not ((kwargs.get("QMSG_KEY") and kwargs.get("QMSG_TYPE")) or (push_config.get("QMSG_KEY") and push_config.get("QMSG_TYPE"))):
         print("qmsg 的 QMSG_KEY 或者 QMSG_TYPE 未设置!!\n取消推送")
         return
     print("qmsg 服务启动")
+    if kwargs.get("QMSG_KEY") and kwargs.get("QMSG_TYPE"):
+        QMSG_KEY = kwargs.get("QMSG_KEY")
+        QMSG_TYPE = kwargs.get("QMSG_TYPE")
+    else:
+        QMSG_KEY = push_config.get("QMSG_KEY")
+        QMSG_TYPE = push_config.get("QMSG_TYPE")
 
-    url = f'https://qmsg.zendee.cn/{push_config.get("QMSG_TYPE")}/{push_config.get("QMSG_KEY")}'
+    url = f'https://qmsg.zendee.cn/{QMSG_TYPE}/{QMSG_KEY}'
     payload = {"msg": f'{title}\n\n{content.replace("----", "-")}'.encode("utf-8")}
     response = requests.post(url=url, params=payload).json()
 

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -753,16 +753,17 @@ def smtp(title: str, content: str, **kwargs) -> None:
         print(f"SMTP 邮件 推送失败！{e}")
 
 
-def pushme(title: str, content: str) -> None:
+def pushme(title: str, content: str, **kwargs) -> None:
     """
     使用 PushMe 推送消息。
     """
-    if not push_config.get("PUSHME_KEY"):
+    if not (kwargs.get("PUSHME_KEY") or push_config.get("PUSHME_KEY")):
         print("PushMe 服务的 PUSHME_KEY 未设置!!\n取消推送")
         return
     print("PushMe 服务启动")
+    PUSHME_KEY = kwargs.get("PUSHME_KEY", push_config.get("PUSHME_KEY"))
 
-    url = f'https://push.i-i.me/?push_key={push_config.get("PUSHME_KEY")}'
+    url = f'https://push.i-i.me/?push_key={PUSHME_KEY}'
     data = {
         "title": title,
         "content": content,

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -253,20 +253,28 @@ def go_cqhttp(title: str, content: str, **kwargs) -> None:
         print("go-cqhttp 推送失败！")
 
 
-def gotify(title: str, content: str) -> None:
+def gotify(title: str, content: str, **kwargs) -> None:
     """
     使用 gotify 推送消息。
     """
-    if not push_config.get("GOTIFY_URL") or not push_config.get("GOTIFY_TOKEN"):
+    if not ((kwargs.get("GOTIFY_URL") and kwargs.get("GOTIFY_TOKEN")) or (push_config.get("GOTIFY_URL") and push_config.get("GOTIFY_TOKEN"))):
         print("gotify 服务的 GOTIFY_URL 或 GOTIFY_TOKEN 未设置!!\n取消推送")
         return
     print("gotify 服务启动")
+    if kwargs.get("GOTIFY_URL") and kwargs.get("GOTIFY_TOKEN"):
+        GOTIFY_URL = kwargs.get("GOTIFY_URL")
+        GOTIFY_TOKEN = kwargs.get("GOBOTGOTIFY_TOKEN_QQ")
+        GOTIFY_PRIORITY = kwargs.get("GOTIFY_PRIORITY")
+    else:
+        GOTIFY_URL = push_config.get("GOTIFY_URL")
+        GOTIFY_TOKEN = push_config.get("GOTIFY_TOKEN")
+        GOTIFY_PRIORITY = kwargs.get("GOTIFY_PRIORITY")
 
-    url = f'{push_config.get("GOTIFY_URL")}/message?token={push_config.get("GOTIFY_TOKEN")}'
+    url = f'{GOTIFY_URL}/message?token={GOTIFY_TOKEN}'
     data = {
         "title": title,
         "message": content,
-        "priority": push_config.get("GOTIFY_PRIORITY"),
+        "priority": GOTIFY_PRIORITY,
     }
     response = requests.post(url, data=data).json()
 

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -327,23 +327,27 @@ def serverJ(title: str, content: str, **kwargs) -> None:
         print(f'serverJ 推送失败！错误码：{response["message"]}')
 
 
-def pushdeer(title: str, content: str) -> None:
+def pushdeer(title: str, content: str, **kwargs) -> None:
     """
     通过PushDeer 推送消息
     """
-    if not push_config.get("DEER_KEY"):
+    if not (kwargs.get("DEER_KEY") or push_config.get("DEER_KEY")):
         print("PushDeer 服务的 DEER_KEY 未设置!!\n取消推送")
         return
     print("PushDeer 服务启动")
+    DEER_KEY = kwargs.get("DEER_KEY", push_config.get("DEER_KEY"))
+
     data = {
         "text": title,
         "desp": content,
         "type": "markdown",
-        "pushkey": push_config.get("DEER_KEY"),
+        "pushkey": DEER_KEY,
     }
     url = "https://api2.pushdeer.com/message/push"
     if push_config.get("DEER_URL"):
         url = push_config.get("DEER_URL")
+    if kwargs.get("DEER_URL"):
+        url = kwargs.get("DEER_URL")
 
     response = requests.post(url, data=data).json()
 

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -284,16 +284,16 @@ def gotify(title: str, content: str, **kwargs) -> None:
         print("gotify 推送失败！")
 
 
-def iGot(title: str, content: str) -> None:
+def iGot(title: str, content: str, **kwargs) -> None:
     """
     使用 iGot 推送消息。
     """
-    if not push_config.get("IGOT_PUSH_KEY"):
+    if not (kwargs.get("IGOT_PUSH_KEY") or push_config.get("IGOT_PUSH_KEY")):
         print("iGot 服务的 IGOT_PUSH_KEY 未设置!!\n取消推送")
         return
     print("iGot 服务启动")
-
-    url = f'https://push.hellyw.com/{push_config.get("IGOT_PUSH_KEY")}'
+    IGOT_PUSH_KEY = kwargs.get("IGOT_PUSH_KEY", push_config.get("IGOT_PUSH_KEY"))
+    url = f'https://push.hellyw.com/{IGOT_PUSH_KEY}'
     data = {"title": title, "content": content}
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     response = requests.post(url, data=data, headers=headers).json()

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -776,27 +776,42 @@ def pushme(title: str, content: str, **kwargs) -> None:
         print(f"PushMe 推送失败！{response.status_code} {response.text}")
 
 
-def chronocat(title: str, content: str) -> None:
+def chronocat(title: str, content: str, **kwargs) -> None:
     """
     使用 CHRONOCAT 推送消息。
     """
-    if (
-        not push_config.get("CHRONOCAT_URL")
-        or not push_config.get("CHRONOCAT_QQ")
-        or not push_config.get("CHRONOCAT_TOKEN")
-    ):
+    if not ((
+        push_config.get("CHRONOCAT_URL")
+        and push_config.get("CHRONOCAT_QQ")
+        and push_config.get("CHRONOCAT_TOKEN")
+    ) or (
+        push_config.get("CHRONOCAT_URL")
+        and push_config.get("CHRONOCAT_QQ")
+        and push_config.get("CHRONOCAT_TOKEN")
+    )):
         print("CHRONOCAT 服务的 CHRONOCAT_URL 或 CHRONOCAT_QQ 未设置!!\n取消推送")
         return
-
     print("CHRONOCAT 服务启动")
+    if (
+        kwargs.get("CHRONOCAT_URL")
+        and kwargs.get("CHRONOCAT_QQ")
+        and kwargs.get("CHRONOCAT_TOKEN")
+    ):
+        CHRONOCAT_URL = kwargs.get("CHRONOCAT_URL")
+        CHRONOCAT_QQ = kwargs.get("CHRONOCAT_QQ")
+        CHRONOCAT_TOKEN = kwargs.get("CHRONOCAT_TOKEN")
+    else:
+        CHRONOCAT_URL = push_config.get("CHRONOCAT_URL")
+        CHRONOCAT_QQ = push_config.get("CHRONOCAT_QQ")
+        CHRONOCAT_TOKEN = push_config.get("CHRONOCAT_TOKEN")
 
-    user_ids = re.findall(r"user_id=(\d+)", push_config.get("CHRONOCAT_QQ"))
-    group_ids = re.findall(r"group_id=(\d+)", push_config.get("CHRONOCAT_QQ"))
+    user_ids = re.findall(r"user_id=(\d+)", CHRONOCAT_QQ)
+    group_ids = re.findall(r"group_id=(\d+)", CHRONOCAT_QQ)
 
-    url = f'{push_config.get("CHRONOCAT_URL")}/api/message/send'
+    url = f'{CHRONOCAT_URL}/api/message/send'
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f'Bearer {push_config.get("CHRONOCAT_TOKEN")}',
+        "Authorization": f'Bearer {CHRONOCAT_TOKEN}',
     }
 
     for chat_type, ids in [(1, user_ids), (2, group_ids)]:

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -172,24 +172,30 @@ def console(title: str, content: str, **kwargs) -> None:
     print(f"{title}\n\n{content}")
 
 
-def dingding_bot(title: str, content: str) -> None:
+def dingding_bot(title: str, content: str, **kwargs) -> None:
     """
     使用 钉钉机器人 推送消息。
     """
-    if not push_config.get("DD_BOT_SECRET") or not push_config.get("DD_BOT_TOKEN"):
+    if not ((kwargs.get("DD_BOT_SECRET") and kwargs.get("DD_BOT_TOKEN")) or (push_config.get("DD_BOT_SECRET") and push_config.get("DD_BOT_TOKEN"))):
         print("钉钉机器人 服务的 DD_BOT_SECRET 或者 DD_BOT_TOKEN 未设置!!\n取消推送")
         return
     print("钉钉机器人 服务启动")
+    if kwargs.get("DD_BOT_SECRET") and kwargs.get("DD_BOT_TOKEN"):
+        DD_BOT_SECRET = kwargs.get("DD_BOT_SECRET")
+        DD_BOT_TOKEN = kwargs.get("DD_BOT_TOKEN")
+    else:
+        DD_BOT_SECRET = push_config.get("DD_BOT_SECRET")
+        DD_BOT_TOKEN = push_config.get("DD_BOT_TOKEN")
 
     timestamp = str(round(time.time() * 1000))
-    secret_enc = push_config.get("DD_BOT_SECRET").encode("utf-8")
-    string_to_sign = "{}\n{}".format(timestamp, push_config.get("DD_BOT_SECRET"))
+    secret_enc = DD_BOT_SECRET.encode("utf-8")
+    string_to_sign = "{}\n{}".format(timestamp, DD_BOT_SECRET)
     string_to_sign_enc = string_to_sign.encode("utf-8")
     hmac_code = hmac.new(
         secret_enc, string_to_sign_enc, digestmod=hashlib.sha256
     ).digest()
     sign = urllib.parse.quote_plus(base64.b64encode(hmac_code))
-    url = f'https://oapi.dingtalk.com/robot/send?access_token={push_config.get("DD_BOT_TOKEN")}&timestamp={timestamp}&sign={sign}'
+    url = f'https://oapi.dingtalk.com/robot/send?access_token={DD_BOT_TOKEN}&timestamp={timestamp}&sign={sign}'
     headers = {"Content-Type": "application/json;charset=utf-8"}
     data = {"msgtype": "text", "text": {"content": f"{title}\n\n{content}"}}
     response = requests.post(

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -571,39 +571,52 @@ def wecom_bot(title: str, content: str, **kwargs) -> None:
         print("企业微信机器人推送失败！")
 
 
-def telegram_bot(title: str, content: str) -> None:
+def telegram_bot(title: str, content: str, **kwargs) -> None:
     """
     使用 telegram 机器人 推送消息。
     """
-    if not push_config.get("TG_BOT_TOKEN") or not push_config.get("TG_USER_ID"):
-        print("tg 服务的 bot_token 或者 user_id 未设置!!\n取消推送")
+    if not ((kwargs.get("TG_BOT_TOKEN") and kwargs.get("TG_USER_ID")) or (push_config.get("TG_BOT_TOKEN") and push_config.get("TG_USER_ID"))):
+        print("tg 服务的 TG_BOT_TOKEN 或者 TG_USER_ID 未设置!!\n取消推送")
         return
     print("tg 服务启动")
+    if kwargs.get("TG_BOT_TOKEN") and kwargs.get("TG_USER_ID"):
+        TG_BOT_TOKEN = kwargs.get("TG_BOT_TOKEN")
+        TG_USER_ID = kwargs.get("TG_USER_ID")
+    else:
+        TG_BOT_TOKEN = push_config.get("TG_BOT_TOKEN")
+        TG_USER_ID = push_config.get("TG_USER_ID")
 
-    if push_config.get("TG_API_HOST"):
-        url = f"{push_config.get('TG_API_HOST')}/bot{push_config.get('TG_BOT_TOKEN')}/sendMessage"
+    if kwargs.get("TG_API_HOST") or push_config.get("TG_API_HOST"):
+        TG_API_HOST = kwargs.get("TG_API_HOST", push_config.get("TG_API_HOST"))
+        url = f"{TG_API_HOST}/bot{TG_BOT_TOKEN}/sendMessage"
     else:
         url = (
-            f"https://api.telegram.org/bot{push_config.get('TG_BOT_TOKEN')}/sendMessage"
+            f"https://api.telegram.org/bot{TG_BOT_TOKEN}/sendMessage"
         )
     headers = {"Content-Type": "application/x-www-form-urlencoded"}
     payload = {
-        "chat_id": str(push_config.get("TG_USER_ID")),
+        "chat_id": str(TG_USER_ID),
         "text": f"{title}\n\n{content}",
         "disable_web_page_preview": "true",
     }
     proxies = None
-    if push_config.get("TG_PROXY_HOST") and push_config.get("TG_PROXY_PORT"):
-        if push_config.get("TG_PROXY_AUTH") is not None and "@" not in push_config.get(
-            "TG_PROXY_HOST"
-        ):
-            push_config["TG_PROXY_HOST"] = (
-                push_config.get("TG_PROXY_AUTH")
+    if not ((kwargs.get("TG_PROXY_HOST") and kwargs.get("TG_PROXY_PORT")) or (push_config.get("TG_PROXY_HOST") and push_config.get("TG_PROXY_PORT"))):
+        if kwargs.get("TG_PROXY_HOST") and kwargs.get("TG_PROXY_PORT"):
+            TG_PROXY_HOST = kwargs.get("TG_PROXY_HOST")
+            TG_PROXY_PORT = kwargs.get("TG_PROXY_PORT")
+        else:
+            TG_PROXY_HOST = kwargs.get("TG_PROXY_HOST")
+            TG_PROXY_PORT = kwargs.get("TG_PROXY_PORT")
+        if kwargs.get("TG_PROXY_AUTH") or push_config.get("TG_PROXY_AUTH"):
+            TG_PROXY_AUTH = kwargs.get("TG_PROXY_AUTH", push_config.get("TG_PROXY_AUTH"))
+        if TG_PROXY_AUTH is not None and "@" not in TG_PROXY_HOST:
+            TG_PROXY_HOST = (
+                TG_PROXY_AUTH
                 + "@"
-                + push_config.get("TG_PROXY_HOST")
+                + TG_PROXY_HOST
             )
         proxyStr = "http://{}:{}".format(
-            push_config.get("TG_PROXY_HOST"), push_config.get("TG_PROXY_PORT")
+            TG_PROXY_HOST, TG_PROXY_PORT
         )
         proxies = {"http": proxyStr, "https": proxyStr}
     response = requests.post(

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -382,21 +382,23 @@ def chat(title: str, content: str, **kwargs) -> None:
         print("Chat 推送失败！错误信息：", response)
 
 
-def pushplus_bot(title: str, content: str) -> None:
+def pushplus_bot(title: str, content: str, **kwargs) -> None:
     """
     通过 push+ 推送消息。
     """
-    if not push_config.get("PUSH_PLUS_TOKEN"):
+    if not (kwargs.get("PUSH_PLUS_TOKEN") or push_config.get("PUSH_PLUS_TOKEN")):
         print("PUSHPLUS 服务的 PUSH_PLUS_TOKEN 未设置!!\n取消推送")
         return
     print("PUSHPLUS 服务启动")
+    PUSH_PLUS_TOKEN = kwargs.get("PUSH_PLUS_TOKEN", push_config.get("PUSH_PLUS_TOKEN"))
+    PUSH_PLUS_USER = kwargs.get("PUSH_PLUS_USER", push_config.get("PUSH_PLUS_USER"))
 
     url = "http://www.pushplus.plus/send"
     data = {
-        "token": push_config.get("PUSH_PLUS_TOKEN"),
+        "token": PUSH_PLUS_TOKEN,
         "title": title,
         "content": content,
-        "topic": push_config.get("PUSH_PLUS_USER"),
+        "topic": PUSH_PLUS_USER,
     }
     body = json.dumps(data).encode(encoding="utf-8")
     headers = {"Content-Type": "application/json"}

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -444,14 +444,15 @@ def qmsg_bot(title: str, content: str, **kwargs) -> None:
         print(f'qmsg 推送失败！{response["reason"]}')
 
 
-def wecom_app(title: str, content: str) -> None:
+def wecom_app(title: str, content: str, **kwargs) -> None:
     """
     通过 企业微信 APP 推送消息。
     """
-    if not push_config.get("QYWX_AM"):
+    if not (kwargs.get("QYWX_AM") or push_config.get("QYWX_AM")):
         print("QYWX_AM 未设置!!\n取消推送")
         return
-    QYWX_AM_AY = re.split(",", push_config.get("QYWX_AM"))
+    QYWX_AM = kwargs.get("QYWX_AM", push_config.get("QYWX_AM"))
+    QYWX_AM_AY = re.split(",", QYWX_AM)
     if 4 < len(QYWX_AM_AY) > 5:
         print("QYWX_AM 设置错误!!\n取消推送")
         return

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -357,16 +357,23 @@ def pushdeer(title: str, content: str, **kwargs) -> None:
         print("PushDeer 推送失败！错误信息：", response)
 
 
-def chat(title: str, content: str) -> None:
+def chat(title: str, content: str, **kwargs) -> None:
     """
     通过Chat 推送消息
     """
-    if not push_config.get("CHAT_URL") or not push_config.get("CHAT_TOKEN"):
+    if not ((kwargs.get("CHAT_URL") and kwargs.get("CHAT_TOKEN")) or (push_config.get("CHAT_URL") and push_config.get("CHAT_TOKEN"))):
         print("chat 服务的 CHAT_URL或CHAT_TOKEN 未设置!!\n取消推送")
         return
     print("chat 服务启动")
+    if kwargs.get("CHAT_URL") and kwargs.get("CHAT_TOKEN"):
+        CHAT_URL = kwargs.get("CHAT_URL")
+        CHAT_TOKEN = kwargs.get("CHAT_TOKEN")
+    else:
+        CHAT_URL = push_config.get("CHAT_URL")
+        CHAT_TOKEN = push_config.get("CHAT_TOKEN")
+
     data = "payload=" + json.dumps({"text": title + "\n" + content})
-    url = push_config.get("CHAT_URL") + push_config.get("CHAT_TOKEN")
+    url = CHAT_URL + CHAT_TOKEN
     response = requests.post(url, data=data)
 
     if response.status_code == 200:

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -304,20 +304,21 @@ def iGot(title: str, content: str, **kwargs) -> None:
         print(f'iGot 推送失败！{response["errMsg"]}')
 
 
-def serverJ(title: str, content: str) -> None:
+def serverJ(title: str, content: str, **kwargs) -> None:
     """
     通过 serverJ 推送消息。
     """
-    if not push_config.get("PUSH_KEY"):
+    if not (kwargs.get("PUSH_KEY") or push_config.get("PUSH_KEY")):
         print("serverJ 服务的 PUSH_KEY 未设置!!\n取消推送")
         return
     print("serverJ 服务启动")
+    PUSH_KEY = kwargs.get("PUSH_KEY", push_config.get("PUSH_KEY"))
 
     data = {"text": title, "desp": content.replace("\n", "\n\n")}
-    if push_config.get("PUSH_KEY").find("SCT") != -1:
-        url = f'https://sctapi.ftqq.com/{push_config.get("PUSH_KEY")}.send'
+    if PUSH_KEY.find("SCT") != -1:
+        url = f'https://sctapi.ftqq.com/{PUSH_KEY}.send'
     else:
-        url = f'https://sc.ftqq.com/{push_config.get("PUSH_KEY")}.send'
+        url = f'https://sc.ftqq.com/{PUSH_KEY}.send'
     response = requests.post(url, data=data).json()
 
     if response.get("errno") == 0 or response.get("code") == 0:

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -629,31 +629,42 @@ def telegram_bot(title: str, content: str, **kwargs) -> None:
         print("tg 推送失败！")
 
 
-def aibotk(title: str, content: str) -> None:
+def aibotk(title: str, content: str, **kwargs) -> None:
     """
     使用 智能微秘书 推送消息。
     """
-    if (
-        not push_config.get("AIBOTK_KEY")
-        or not push_config.get("AIBOTK_TYPE")
-        or not push_config.get("AIBOTK_NAME")
+    if not (
+        kwargs.get("AIBOTK_KEY")
+        and kwargs.get("AIBOTK_TYPE")
+        and kwargs.get("AIBOTK_NAME")
+    )or (
+        push_config.get("AIBOTK_KEY")
+        and push_config.get("AIBOTK_TYPE")
+        and push_config.get("AIBOTK_NAME")
     ):
         print("智能微秘书 的 AIBOTK_KEY 或者 AIBOTK_TYPE 或者 AIBOTK_NAME 未设置!!\n取消推送")
         return
     print("智能微秘书 服务启动")
-
-    if push_config.get("AIBOTK_TYPE") == "room":
+    if kwargs.get("AIBOTK_KEY") and kwargs.get("AIBOTK_TYPE") and kwargs.get("AIBOTK_NAME"):
+        AIBOTK_KEY = kwargs.get("AIBOTK_KEY")
+        AIBOTK_TYPE = kwargs.get("AIBOTK_TYPE")
+        AIBOTK_NAME = kwargs.get("AIBOTK_NAME")
+    else:
+        AIBOTK_KEY = push_config.get("AIBOTK_KEY")
+        AIBOTK_TYPE = push_config.get("AIBOTK_TYPE")
+        AIBOTK_NAME = push_config.get("AIBOTK_NAME")
+    if AIBOTK_TYPE == "room":
         url = "https://api-bot.aibotk.com/openapi/v1/chat/room"
         data = {
-            "apiKey": push_config.get("AIBOTK_KEY"),
-            "roomName": push_config.get("AIBOTK_NAME"),
+            "apiKey": AIBOTK_KEY,
+            "roomName": AIBOTK_NAME,
             "message": {"type": 1, "content": f"【青龙快讯】\n\n{title}\n{content}"},
         }
     else:
         url = "https://api-bot.aibotk.com/openapi/v1/chat/contact"
         data = {
-            "apiKey": push_config.get("AIBOTK_KEY"),
-            "name": push_config.get("AIBOTK_NAME"),
+            "apiKey": AIBOTK_KEY,
+            "name": AIBOTK_NAME,
             "message": {"type": 1, "content": f"【青龙快讯】\n\n{title}\n{content}"},
         }
     body = json.dumps(data).encode(encoding="utf-8")

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -208,16 +208,16 @@ def dingding_bot(title: str, content: str, **kwargs) -> None:
         print("钉钉机器人 推送失败！")
 
 
-def feishu_bot(title: str, content: str) -> None:
+def feishu_bot(title: str, content: str, **kwargs) -> None:
     """
     使用 飞书机器人 推送消息。
     """
-    if not push_config.get("FSKEY"):
+    if not (kwargs.get("DD_BOT_SECRET") or push_config.get("FSKEY")):
         print("飞书 服务的 FSKEY 未设置!!\n取消推送")
         return
     print("飞书 服务启动")
-
-    url = f'https://open.feishu.cn/open-apis/bot/v2/hook/{push_config.get("FSKEY")}'
+    FSKEY = kwargs.get("DD_BOT_SECRET", push_config.get("FSKEY"))
+    url = f'https://open.feishu.cn/open-apis/bot/v2/hook/{FSKEY}'
     data = {"msg_type": "text", "content": {"text": f"{title}\n\n{content}"}}
     response = requests.post(url, data=json.dumps(data)).json()
 

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -677,50 +677,74 @@ def aibotk(title: str, content: str, **kwargs) -> None:
         print(f'智能微秘书 推送失败！{response["error"]}')
 
 
-def smtp(title: str, content: str) -> None:
+def smtp(title: str, content: str, **kwargs) -> None:
     """
     使用 SMTP 邮件 推送消息。
     """
-    if (
-        not push_config.get("SMTP_SERVER")
-        or not push_config.get("SMTP_SSL")
-        or not push_config.get("SMTP_EMAIL")
-        or not push_config.get("SMTP_PASSWORD")
-        or not push_config.get("SMTP_NAME")
-    ):
+    if not ((
+        kwargs.get("SMTP_SERVER")
+        and kwargs.get("SMTP_SSL")
+        and kwargs.get("SMTP_EMAIL")
+        and kwargs.get("SMTP_PASSWORD")
+        and kwargs.get("SMTP_NAME")
+    ) or (
+        push_config.get("SMTP_SERVER")
+        and push_config.get("SMTP_SSL")
+        and push_config.get("SMTP_EMAIL")
+        and push_config.get("SMTP_PASSWORD")
+        and push_config.get("SMTP_NAME")
+    )):
         print(
             "SMTP 邮件 的 SMTP_SERVER 或者 SMTP_SSL 或者 SMTP_EMAIL 或者 SMTP_PASSWORD 或者 SMTP_NAME 未设置!!\n取消推送"
         )
         return
     print("SMTP 邮件 服务启动")
+    if (
+        kwargs.get("SMTP_SERVER")
+        and kwargs.get("SMTP_SSL")
+        and kwargs.get("SMTP_EMAIL")
+        and kwargs.get("SMTP_PASSWORD")
+        and kwargs.get("SMTP_NAME")
+    ):
+        SMTP_SERVER = kwargs.get("SMTP_SERVER")
+        SMTP_SSL = kwargs.get("SMTP_SSL")
+        SMTP_EMAIL = kwargs.get("SMTP_EMAIL")
+        SMTP_PASSWORD = kwargs.get("SMTP_PASSWORD")
+        SMTP_NAME = kwargs.get("SMTP_NAME")
+    else:
+        SMTP_SERVER = push_config.get("SMTP_SERVER")
+        SMTP_SSL = push_config.get("SMTP_SSL")
+        SMTP_EMAIL = push_config.get("SMTP_EMAIL")
+        SMTP_PASSWORD = push_config.get("SMTP_PASSWORD")
+        SMTP_NAME = push_config.get("SMTP_NAME")
 
     message = MIMEText(content, "plain", "utf-8")
     message["From"] = formataddr(
         (
-            Header(push_config.get("SMTP_NAME"), "utf-8").encode(),
-            push_config.get("SMTP_EMAIL"),
+            Header(SMTP_NAME, "utf-8").encode(),
+            SMTP_EMAIL,
         )
     )
     message["To"] = formataddr(
         (
-            Header(push_config.get("SMTP_NAME"), "utf-8").encode(),
-            push_config.get("SMTP_EMAIL"),
+            Header(SMTP_NAME, "utf-8").encode(),
+            SMTP_EMAIL,
         )
     )
     message["Subject"] = Header(title, "utf-8")
 
     try:
         smtp_server = (
-            smtplib.SMTP_SSL(push_config.get("SMTP_SERVER"))
-            if push_config.get("SMTP_SSL") == "true"
-            else smtplib.SMTP(push_config.get("SMTP_SERVER"))
+            smtplib.SMTP_SSL(SMTP_SERVER)
+            if SMTP_SSL == "true"
+            else smtplib.SMTP(SMTP_SERVER)
         )
         smtp_server.login(
-            push_config.get("SMTP_EMAIL"), push_config.get("SMTP_PASSWORD")
+            SMTP_EMAIL, SMTP_PASSWORD
         )
         smtp_server.sendmail(
-            push_config.get("SMTP_EMAIL"),
-            push_config.get("SMTP_EMAIL"),
+            SMTP_EMAIL,
+            SMTP_EMAIL,
             message.as_bytes(),
         )
         smtp_server.close()

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -634,14 +634,18 @@ def aibotk(title: str, content: str, **kwargs) -> None:
     使用 智能微秘书 推送消息。
     """
     if not (
-        kwargs.get("AIBOTK_KEY")
-        and kwargs.get("AIBOTK_TYPE")
-        and kwargs.get("AIBOTK_NAME")
-    )or (
-        push_config.get("AIBOTK_KEY")
-        and push_config.get("AIBOTK_TYPE")
-        and push_config.get("AIBOTK_NAME")
-    ):
+        (
+            kwargs.get("AIBOTK_KEY")
+            and kwargs.get("AIBOTK_TYPE")
+            and kwargs.get("AIBOTK_NAME")
+        ) 
+        or
+        (
+            push_config.get("AIBOTK_KEY")
+            and push_config.get("AIBOTK_TYPE")
+            and push_config.get("AIBOTK_NAME")
+        )
+        ):
         print("智能微秘书 的 AIBOTK_KEY 或者 AIBOTK_TYPE 或者 AIBOTK_NAME 未设置!!\n取消推送")
         return
     print("智能微秘书 服务启动")

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -227,16 +227,24 @@ def feishu_bot(title: str, content: str, **kwargs) -> None:
         print("飞书 推送失败！错误信息如下：\n", response)
 
 
-def go_cqhttp(title: str, content: str) -> None:
+def go_cqhttp(title: str, content: str, **kwargs) -> None:
     """
     使用 go_cqhttp 推送消息。
     """
-    if not push_config.get("GOBOT_URL") or not push_config.get("GOBOT_QQ"):
+    if not ((kwargs.get("GOBOT_URL") and kwargs.get("GOBOT_QQ")) or (push_config.get("GOBOT_URL") and push_config.get("GOBOT_QQ"))):
         print("go-cqhttp 服务的 GOBOT_URL 或 GOBOT_QQ 未设置!!\n取消推送")
         return
     print("go-cqhttp 服务启动")
+    if kwargs.get("GOBOT_URL") and kwargs.get("GOBOT_QQ"):
+        GOBOT_URL = kwargs.get("GOBOT_URL")
+        GOBOT_QQ = kwargs.get("GOBOT_QQ")
+        GOBOT_TOKEN = kwargs.get("GOBOT_TOKEN")
+    else:
+        GOBOT_URL = push_config.get("GOBOT_URL")
+        GOBOT_QQ = push_config.get("GOBOT_QQ")
+        GOBOT_TOKEN = push_config.get("GOBOT_TOKEN")
 
-    url = f'{push_config.get("GOBOT_URL")}?access_token={push_config.get("GOBOT_TOKEN")}&{push_config.get("GOBOT_QQ")}&message=标题:{title}\n内容:{content}'
+    url = f'{GOBOT_URL}?access_token={GOBOT_TOKEN}&{GOBOT_QQ}&message=标题:{title}\n内容:{content}'
     response = requests.get(url).json()
 
     if response["status"] == "ok":

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -542,20 +542,23 @@ class WeCom:
         return respone["errmsg"]
 
 
-def wecom_bot(title: str, content: str) -> None:
+def wecom_bot(title: str, content: str, **kwargs) -> None:
     """
     通过 企业微信机器人 推送消息。
     """
-    if not push_config.get("QYWX_KEY"):
+    if not (kwargs.get("QYWX_KEY") or push_config.get("QYWX_KEY")):
         print("企业微信机器人 服务的 QYWX_KEY 未设置!!\n取消推送")
         return
     print("企业微信机器人服务启动")
+    QYWX_KEY = kwargs.get("QYWX_KEY", push_config.get("QYWX_KEY"))
 
     origin = "https://qyapi.weixin.qq.com"
     if push_config.get("QYWX_ORIGIN"):
         origin = push_config.get("QYWX_ORIGIN")
+    if kwargs.get("QYWX_ORIGIN"):
+        origin = kwargs.get("QYWX_ORIGIN")
 
-    url = f"{origin}/cgi-bin/webhook/send?key={push_config.get('QYWX_KEY')}"
+    url = f"{origin}/cgi-bin/webhook/send?key={QYWX_KEY}"
     headers = {"Content-Type": "application/json;charset=utf-8"}
     data = {"msgtype": "text", "text": {"content": f"{title}\n\n{content}"}}
     response = requests.post(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
### 功能
其他函数在调用notify.send()函数时候可以通过关键字参数`**kwargs`自定义发送信息等参数，且关键字参数优先级高于通过环境变量设置的参数

### 示例
原本我设置了Bark推送`BARK_PUSH="aaaaaaaa"`，但在某个脚本中，我想给`bbbbbbb`推送信息，可以使用下面的方法：
```python
notify.send("测试标题", "测试内容", BARK_PUSH="bbbbbbb")
```
这样既不影响其他脚本将推送发给`aaaaaaaa`也能使得某些特殊的程序将信息推送给`bbbbbbb`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
### 关于代码检查
**目前仅在Bark测试无误**，测试代码：
```python
import notify

if __name__ == "__main__":
    notify.send("测试标题", "测试内容", BARK_PUSH="aC6xxxxxxxxxxj2C", BARK_GROUP="测试", BARK_URL="https://baidu.com")
```
### 已知可能会出现的BUG
1.  如果原本环境变量未开启相关推送，基本在关键字参数中配置对应方法也无法推送（~~不确定这个算是features还是bug~~）
     例如我在环境变量中没有设置`BARK_PUSH`的值，推送服务会认为没有配置Bark参数，所以不会调用`bark()`函数，所以基本是在调用时配置的`BARK_PUSH`也不会推送` notify.send("测试标题", "测试内容", BARK_PUSH="aC6xxxxxxxxxxj2C"`
2. 由于我只用Bark，不太清楚其他推送服务的token、secret、id等配置是否需要一一对应
    举一个简单的例子，就是邮件推送，`SMTP_SERVER`、`SMTP_EMAIL`等有关邮件发送端的变量需要一一对应，所以必须判断传入的关键字参数必须包含完整的SMTP服务器信息，如果信息包含不完全就会退回使用环境变量的参数，不能`SMTP_SERVER`使用传入的参数而`SMTP_EMAIL`使用环境变量（~~虽然也可以，但需要用户自适应~~）；但是发送端的参数可以和接受邮件的人使用的参数来源是不用的，例如SMTP相关的参数使用环境变量，而接受邮件使用传入的参数，这是可以正确运行的，这两种参数就是不需要一一对应的。由于我只用过Bark，不太确定其他推送服务的这些变量间关系是否需要一一对应，所以这里基本就是我的凭借猜想完全的，需要更加详细的Debug。不过好在原本使用`send("标题", "内容")`的这种方法不会受到上面所述的影响