### PR TITLE
适配Server酱APP分支（Server酱³），移除已废弃的旧版api入口

### DIFF
--- a/back/services/notify.ts
+++ b/back/services/notify.ts
@@ -151,9 +151,9 @@ export default class NotificationService {
 
   private async serverChan() {
     const { serverChanKey } = this.params;
-    const url = serverChanKey.startsWith('SCT')
-      ? `https://sctapi.ftqq.com/${serverChanKey}.send`
-      : `https://sc.ftqq.com/${serverChanKey}.send`;
+    const url = serverChanKey.startsWith('sctp')
+      ? `https://${serverChanKey}.push.ft07.com/send`
+      : `https://sctapi.ftqq.com/${serverChanKey}.send`;
     try {
       const res: any = await got
         .post(url, {

--- a/sample/notify.js
+++ b/sample/notify.js
@@ -225,9 +225,9 @@ function serverNotify(text, desp) {
       // 微信server酱推送通知一个\n不会换行，需要两个\n才能换行，故做此替换
       desp = desp.replace(/[\n\r]/g, '\n\n');
       const options = {
-        url: PUSH_KEY.includes('SCT')
-          ? `https://sctapi.ftqq.com/${PUSH_KEY}.send`
-          : `https://sc.ftqq.com/${PUSH_KEY}.send`,
+        url: PUSH_KEY.startsWith('sctp')
+          ? `https://${PUSH_KEY}.push.ft07.com/send`
+          : `https://sctapi.ftqq.com/${PUSH_KEY}.send`,
         body: `text=${text}&desp=${desp}`,
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded',

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -298,10 +298,10 @@ def serverJ(title: str, content: str) -> None:
     print("serverJ 服务启动")
 
     data = {"text": title, "desp": content.replace("\n", "\n\n")}
-    if push_config.get("PUSH_KEY").find("SCT") != -1:
-        url = f'https://sctapi.ftqq.com/{push_config.get("PUSH_KEY")}.send'
+    if push_config.get("PUSH_KEY").startswith("sctp"):
+        url = f'https://{push_config.get("PUSH_KEY")}.push.ft07.com/send'
     else:
-        url = f'https://sc.ftqq.com/{push_config.get("PUSH_KEY")}.send'
+        url = f'https://sctapi.ftqq.com/{push_config.get("PUSH_KEY")}.send'
     response = requests.post(url, data=data).json()
 
     if response.get("errno") == 0 or response.get("code") == 0:


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

Feature：适配Server酱APP分支（Server酱³）
Bugfix：移除已废弃的旧版api入口


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


const url: PUSH_KEY.includes('SCT')
     ? `https://sctapi.ftqq.com/${PUSH_KEY}.send`
    `https://sc.ftqq.com/${PUSH_KEY}.send`,


## What is the new behavior?

 const url = String(key).startsWith('sctp') 
        ? `https://${key}.push.ft07.com/send`
        : `https://sctapi.ftqq.com/${key}.send`;


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

sc.ftqq.com 入口已经废弃，由 sctapi.ftqq.com 替代。


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information