### PR TITLE
SMTP 邮件通知支持收发分离、支持多收件人；调整一言启用逻辑，默认关闭；

### DIFF
--- a/sample/notify.js
+++ b/sample/notify.js
@@ -964,8 +964,8 @@ function fsBotNotify(text, desp) {
 }
 
 async function smtpNotify(text, desp) {
-  const { SMTP_EMAIL, SMTP_PASSWORD, SMTP_SERVICE, SMTP_NAME } = push_config;
-  if (![SMTP_EMAIL, SMTP_PASSWORD].every(Boolean) || !SMTP_SERVICE) {
+  const { SMTP_EMAIL, SMTP_PASSWORD, SMTP_SERVICE, SMTP_NAME, SMTP_EMAIL_TO, SMTP_NAME_TO } = push_config;
+  if (!SMTP_EMAIL || !SMTP_PASSWORD || !SMTP_SERVICE) {
     return;
   }
 
@@ -979,10 +979,24 @@ async function smtpNotify(text, desp) {
       },
     });
 
-    const addr = SMTP_NAME ? `"${SMTP_NAME}" <${SMTP_EMAIL}>` : SMTP_EMAIL;
+    const fromAddr = SMTP_NAME ? `"${SMTP_NAME}" <${SMTP_EMAIL}>` : SMTP_EMAIL;
+
+    let toAddr;
+    if (SMTP_EMAIL_TO) {
+      // 处理多个收件人
+      const emailTos = SMTP_EMAIL_TO.split(',');
+      const nameTos = (SMTP_NAME_TO || "").split(',');
+      toAddr = emailTos.map((email, index) => {
+        const name = nameTos[index] || "";
+        return name ? `"${name}" <${email}>` : email;
+      });
+    } else {
+      toAddr = fromAddr;
+    }
+
     const info = await transporter.sendMail({
-      from: addr,
-      to: addr,
+      from: fromAddr,
+      to: toAddr,
       subject: text,
       html: `${desp.replace(/\n/g, '<br/>')}`,
     });

--- a/sample/notify.js
+++ b/sample/notify.js
@@ -79,9 +79,11 @@ const push_config = {
   AIBOTK_NAME: '', // 智能微秘书  发送群名 或者好友昵称和type要对应好
 
   SMTP_SERVICE: '', // 邮箱服务名称，比如 126、163、Gmail、QQ 等，支持列表 https://github.com/nodemailer/nodemailer/blob/master/lib/well-known/services.json
-  SMTP_EMAIL: '', // SMTP 收发件邮箱，通知将会由自己发给自己
+  SMTP_EMAIL: '', // SMTP 发件邮箱
   SMTP_PASSWORD: '', // SMTP 登录密码，也可能为特殊口令，视具体邮件服务商说明而定
-  SMTP_NAME: '', // SMTP 收发件人姓名，可随意填写
+  SMTP_NAME: '', // SMTP 发件人姓名，可随意填写
+  SMTP_EMAIL_TO: '', //SMTP 收件邮箱，可选，缺省时将自己发给自己，多个收件邮箱逗号间隔
+  SMTP_NAME_TO: '', //SMTP 收件人姓名，可选，可随意填写，多个收件人逗号间隔，顺序与 SMTP_EMAIL_TO 保持一致
 
   PUSHME_KEY: '', // 官方文档：https://push.i-i.me，PushMe 酱的 PUSHME_KEY
 

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -33,7 +33,7 @@ def print(text, *args, **kw):
 # 通知服务
 # fmt: off
 push_config = {
-    'HITOKOTO': True,                  # 启用一言（随机句子）
+    'HITOKOTO': True,                   # 启用一言（随机句子）
 
     'BARK_PUSH': '',                    # bark IP 或设备码，例：https://api.day.app/DxHcxxxxxRxxxxxxcm/
     'BARK_ARCHIVE': '',                 # bark 推送是否存档
@@ -43,7 +43,7 @@ push_config = {
     'BARK_LEVEL': '',                   # bark 推送时效性
     'BARK_URL': '',                     # bark 推送跳转URL
 
-    'CONSOLE': False,                    # 控制台输出
+    'CONSOLE': False,                   # 控制台输出
 
     'DD_BOT_SECRET': '',                # 钉钉机器人的 DD_BOT_SECRET
     'DD_BOT_TOKEN': '',                 # 钉钉机器人的 DD_BOT_TOKEN
@@ -77,7 +77,7 @@ push_config = {
 
     'WE_PLUS_BOT_TOKEN': '',            # 微加机器人的用户令牌
     'WE_PLUS_BOT_RECEIVER': '',         # 微加机器人的消息接收者
-    'WE_PLUS_BOT_VERSION': 'pro',          # 微加机器人的调用版本
+    'WE_PLUS_BOT_VERSION': 'pro',       # 微加机器人的调用版本
 
     'QMSG_KEY': '',                     # qmsg 酱的 QMSG_KEY
     'QMSG_TYPE': '',                    # qmsg 酱的 QMSG_TYPE
@@ -817,7 +817,7 @@ def ntfy(title: str, content: str) -> None:
         print("ntfy 服务的NTFY_PRIORITY 未设置!!默认设置为3")
     else:
         priority = push_config.get("NTFY_PRIORITY")
-    
+
     # 使用 RFC 2047 编码 title
     encoded_title = encode_rfc2047(title)
 
@@ -826,7 +826,7 @@ def ntfy(title: str, content: str) -> None:
         "Title": encoded_title,  # 使用编码后的 title
         "Priority": priority
     }
-    
+
     url = push_config.get("NTFY_URL") + "/" + push_config.get("NTFY_TOPIC")
     response = requests.post(url, data=data, headers=headers)
     if response.status_code == 200:  # 使用 response.status_code 进行检查
@@ -1020,7 +1020,7 @@ def send(title: str, content: str, ignore_default_config: bool = False, **kwargs
             print(f"{title} 在SKIP_PUSH_TITLE环境变量内，跳过推送！")
             return
 
-    hitokoto = push_config.get("HITOKOTO")
+    hitokoto = push_config.get("HITOKOTO", "false")
     content += "\n\n" + one() if hitokoto != "false" else ""
 
     notify_function = add_notify_function()


### PR DESCRIPTION
1. **SMTP 邮件通知支持收发分离、支持多收件人** (1aa9a06989c969037fa78d74f7b25d4547774ae2)
    > 当存在 `SMTP_EMAIL_TO` 变量时，允许邮件收件人和发件人分离，不存在时则自己发给自己（不影响现有用户）
    >  `SMTP_EMAIL_TO` 支持多收件人，写法 `a@a.com` 或 `a@a.com,b@b.com` …
    >  `SMTP_NAME_TO` 收件人姓名同理，写法 `aNAME` 或 `aNAME,bNAME` … 顺序和SMTP_EMAIL_TO保持一致

2. **调整一言启用逻辑，默认不启用** (24d2e45bd58507daa9bf5092fe0cd658e869aa17)
    > 原逻辑：**默认推送，需主动关闭**，仅当 `HITOKOTO` =`false` 时，才不推送一言（即使`HITOKOTO`变量未设置，也会推送）
    > 调整后：**默认关闭，需主动开启**，`HITOKOTO`未设置或`HITOKOTO` =`false` 时不推送，当`HITOKOTO` 设置任意值时推送
    > 我觉得一言作为一个附加功能，**默认关闭，需主动开启**较为合适。