### PR TITLE
SMTP 邮件通知支持收发分离、支持多收件人

### DIFF
--- a/sample/notify.js
+++ b/sample/notify.js
@@ -79,9 +79,11 @@ const push_config = {
   AIBOTK_NAME: '', // 智能微秘书  发送群名 或者好友昵称和type要对应好
 
   SMTP_SERVICE: '', // 邮箱服务名称，比如 126、163、Gmail、QQ 等，支持列表 https://github.com/nodemailer/nodemailer/blob/master/lib/well-known/services.json
-  SMTP_EMAIL: '', // SMTP 收发件邮箱，通知将会由自己发给自己
+  SMTP_EMAIL: '', // SMTP 发件邮箱
   SMTP_PASSWORD: '', // SMTP 登录密码，也可能为特殊口令，视具体邮件服务商说明而定
-  SMTP_NAME: '', // SMTP 收发件人姓名，可随意填写
+  SMTP_NAME: '', // SMTP 发件人姓名，可随意填写
+  SMTP_EMAIL_TO: '', //SMTP 收件邮箱，可选，缺省时将自己发给自己，多个收件邮箱逗号间隔
+  SMTP_NAME_TO: '', //SMTP 收件人姓名，可选，可随意填写，多个收件人逗号间隔，顺序与 SMTP_EMAIL_TO 保持一致
 
   PUSHME_KEY: '', // 官方文档：https://push.i-i.me，PushMe 酱的 PUSHME_KEY
 
@@ -964,8 +966,8 @@ function fsBotNotify(text, desp) {
 }
 
 async function smtpNotify(text, desp) {
-  const { SMTP_EMAIL, SMTP_PASSWORD, SMTP_SERVICE, SMTP_NAME } = push_config;
-  if (![SMTP_EMAIL, SMTP_PASSWORD].every(Boolean) || !SMTP_SERVICE) {
+  const { SMTP_EMAIL, SMTP_PASSWORD, SMTP_SERVICE, SMTP_NAME, SMTP_EMAIL_TO, SMTP_NAME_TO } = push_config;
+  if (!SMTP_EMAIL || !SMTP_PASSWORD || !SMTP_SERVICE) {
     return;
   }
 
@@ -979,10 +981,24 @@ async function smtpNotify(text, desp) {
       },
     });
 
-    const addr = SMTP_NAME ? `"${SMTP_NAME}" <${SMTP_EMAIL}>` : SMTP_EMAIL;
+    const fromAddr = SMTP_NAME ? `"${SMTP_NAME}" <${SMTP_EMAIL}>` : SMTP_EMAIL;
+
+    let toAddr;
+    if (SMTP_EMAIL_TO) {
+      // 处理多个收件人
+      const emailTos = SMTP_EMAIL_TO.split(',');
+      const nameTos = (SMTP_NAME_TO || "").split(',');
+      toAddr = emailTos.map((email, index) => {
+        const name = nameTos[index] || "";
+        return name ? `"${name}" <${email}>` : email;
+      });
+    } else {
+      toAddr = fromAddr;
+    }
+
     const info = await transporter.sendMail({
-      from: addr,
-      to: addr,
+      from: fromAddr,
+      to: toAddr,
       subject: text,
       html: `${desp.replace(/\n/g, '<br/>')}`,
     });


### PR DESCRIPTION
### SMTP 邮件通知支持收发分离、支持多收件人
1. 当存在 `SMTP_EMAIL_TO` 变量时，允许邮件收件人和发件人分离，不存在时则自己发给自己（不影响现有用户）
2. `SMTP_EMAIL_TO` 支持多收件人，写法 `a@a.com` 或 `a@a.com,b@b.com` …
3. `SMTP_NAME_TO` 收件人姓名同理，写法 `aNAME` 或 `aNAME,bNAME` … 顺序和`SMTP_EMAIL_TO`保持一致