### PR TITLE
调整一言启用逻辑，默认关闭

### DIFF
--- a/sample/notify.js
+++ b/sample/notify.js
@@ -3,7 +3,7 @@ const got = require('got');
 const timeout = 15000;
 
 const push_config = {
-  HITOKOTO: true, // 启用一言（随机句子）
+  HITOKOTO: false, // 启用一言（随机句子）
 
   BARK_PUSH: '', // bark IP 或设备码，例：https://api.day.app/DxHcxxxxxRxxxxxxcm/
   BARK_ARCHIVE: '', // bark 推送是否存档
@@ -1205,7 +1205,7 @@ function ntfyNotify(text, desp) {
     if (NTFY_TOPIC) {
       const options = {
         url: `${NTFY_URL || 'https://ntfy.sh'}/${NTFY_TOPIC}`,
-        body: `${desp}`, 
+        body: `${desp}`,
         headers: {
           'Title': `${encodeRFC2047(text)}`,
           'Priority': NTFY_PRIORITY || '3'
@@ -1339,7 +1339,7 @@ async function sendNotify(text, desp, params = {}) {
     }
   }
 
-  if (push_config.HITOKOTO !== 'false') {
+  if (push_config.HITOKOTO && String(push_config.HITOKOTO).toLowerCase() !== 'false') {
     desp += '\n\n' + (await one());
   }
 

--- a/sample/notify.py
+++ b/sample/notify.py
@@ -33,7 +33,7 @@ def print(text, *args, **kw):
 # 通知服务
 # fmt: off
 push_config = {
-    'HITOKOTO': True,                  # 启用一言（随机句子）
+    'HITOKOTO': False,                  # 启用一言（随机句子）
 
     'BARK_PUSH': '',                    # bark IP 或设备码，例：https://api.day.app/DxHcxxxxxRxxxxxxcm/
     'BARK_ARCHIVE': '',                 # bark 推送是否存档
@@ -43,7 +43,7 @@ push_config = {
     'BARK_LEVEL': '',                   # bark 推送时效性
     'BARK_URL': '',                     # bark 推送跳转URL
 
-    'CONSOLE': False,                    # 控制台输出
+    'CONSOLE': False,                   # 控制台输出
 
     'DD_BOT_SECRET': '',                # 钉钉机器人的 DD_BOT_SECRET
     'DD_BOT_TOKEN': '',                 # 钉钉机器人的 DD_BOT_TOKEN
@@ -77,7 +77,7 @@ push_config = {
 
     'WE_PLUS_BOT_TOKEN': '',            # 微加机器人的用户令牌
     'WE_PLUS_BOT_RECEIVER': '',         # 微加机器人的消息接收者
-    'WE_PLUS_BOT_VERSION': 'pro',          # 微加机器人的调用版本
+    'WE_PLUS_BOT_VERSION': 'pro',       # 微加机器人的调用版本
 
     'QMSG_KEY': '',                     # qmsg 酱的 QMSG_KEY
     'QMSG_TYPE': '',                    # qmsg 酱的 QMSG_TYPE
@@ -804,7 +804,7 @@ def ntfy(title: str, content: str) -> None:
         print("ntfy 服务的NTFY_PRIORITY 未设置!!默认设置为3")
     else:
         priority = push_config.get("NTFY_PRIORITY")
-    
+
     # 使用 RFC 2047 编码 title
     encoded_title = encode_rfc2047(title)
 
@@ -813,7 +813,7 @@ def ntfy(title: str, content: str) -> None:
         "Title": encoded_title,  # 使用编码后的 title
         "Priority": priority
     }
-    
+
     url = push_config.get("NTFY_URL") + "/" + push_config.get("NTFY_TOPIC")
     response = requests.post(url, data=data, headers=headers)
     if response.status_code == 200:  # 使用 response.status_code 进行检查
@@ -1008,7 +1008,8 @@ def send(title: str, content: str, ignore_default_config: bool = False, **kwargs
             return
 
     hitokoto = push_config.get("HITOKOTO")
-    content += "\n\n" + one() if hitokoto != "false" else ""
+    if hitokoto and str(hitokoto).lower() != "false":
+        content += "\n\n" + one()
 
     notify_function = add_notify_function()
     ts = [


### PR DESCRIPTION
### 调整一言启用逻辑，默认关闭

- 原逻辑：**默认开启，需主动关闭**，即仅当`HITOKOTO`=`false`时，才不开启一言（**即使`HITOKOTO`变量未设置，也会开启**）
- 调整后：**默认关闭，需主动开启**，即`HITOKOTO`设置且`HITOKOTO`!=`false`时开启，未设置时不开启

我觉得一言作为一个附加的功能，并且会增加网络请求，**保持默认关闭，让用户主动行为来开启**较为合适。

Issues 区也有类似反馈，#2504