### PR TITLE
Fix: ql command not found

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -27,7 +27,13 @@ if [ -f /etc/alpine-release ]; then
   fi
 fi
 
-log_with_style "INFO" "🚀  1. 检测配置文件..."
+log_with_style "INFO" "预先创建软连接..."
+if [[ ! -d "$HOME/bin" ]]; then
+  mkdir -p "$HOME/bin"
+fi
+ln -sf "$dir_shell/update.sh" "$HOME/bin/ql"
+ln -sf "$dir_shell/task.sh" "$HOME/bin/task"
+
 load_ql_envs
 export_ql_envs
 . $dir_shell/env.sh

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -34,6 +34,7 @@ fi
 ln -sf "$dir_shell/update.sh" "$HOME/bin/ql"
 ln -sf "$dir_shell/task.sh" "$HOME/bin/task"
 
+log_with_style "INFO" "🚀 1. 检测配置文件..."
 load_ql_envs
 export_ql_envs
 . $dir_shell/env.sh


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The default [ql](qinglong/shell/share.sh:81:0-86:1) command behaves inconsistently during container startup.
- The entrypoint script attempts to execute [ql](qinglong/shell/share.sh:81:0-86:1) commands shortly after starting the backend.
- However, the [ql](qinglong/shell/share.sh:81:0-86:1) and [task](qinglong/shell/share.sh:385:0-393:1) symlinks are created asynchronously by the backend initialization process.
- **Race Condition**: If the backend is slow to initialize, the entrypoint script executes before the symlinks exist, causing "command not found" errors.


## What is the new behavior?
Explicitly pre-create the necessary symlinks for [ql](qinglong/shell/share.sh:81:0-86:1) and [task](qinglong/shell/share.sh:385:0-393:1) commands in the entrypoint script **before** any commands are invoked.
- This ensures the commands are always available immediately during startup, regardless of backend initialization speed.
- This change is idempotent and compatible with the existing backend logic.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This fix eliminates the startup race condition by decoupling the shell environment setup from the Node.js backend initialization timing.