### PR TITLE
fix: exclude dependency files from scheduled tasks when pulling subsc…

### DIFF
--- a/shell/update.sh
+++ b/shell/update.sh
@@ -397,10 +397,9 @@ gen_list_repo() {
   if [[ $blackword ]]; then
     files=$(echo "$files" | egrep -v "$blackword")
   fi
-# Filter out dependency files from the scripts list
-if [[ $dependence ]]; then
-  files=$(echo "$files" | egrep -v "$dependence")
-fi
+  if [[ $dependence ]]; then
+    files=$(echo "$files" | egrep -v "$dependence")
+  fi
 
   cp -f $file_notify_js "${dir_scripts}/${uniq_path}"
   cp -f $file_notify_py "${dir_scripts}/${uniq_path}"

--- a/shell/update.sh
+++ b/shell/update.sh
@@ -397,6 +397,10 @@ gen_list_repo() {
   if [[ $blackword ]]; then
     files=$(echo "$files" | egrep -v "$blackword")
   fi
+# Filter out dependency files from the scripts list
+if [[ $dependence ]]; then
+  files=$(echo "$files" | egrep -v "$dependence")
+fi
 
   cp -f $file_notify_js "${dir_scripts}/${uniq_path}"
   cp -f $file_notify_py "${dir_scripts}/${uniq_path}"


### PR DESCRIPTION
## 问题描述
当在订阅中设置了依赖文件的文件名（dependence），拉取订阅后，该依赖文件依旧会被加入到定时任务里。

## 根本原因
在 `gen_list_repo()` 函数中，依赖文件被复制到脚本目录后，但在生成脚本列表时没有将其排除。因此，如果依赖文件名称包含脚本扩展名（如 .js、.py），它仍然会被当作普通脚本加入到任务列表中。

## 修复方案
在生成脚本列表时，添加额外的过滤逻辑，排除指定的依赖文件名称：

```shell
if [[ $dependence ]]; then
  files=$(echo "$files" | egrep -v "$dependence")
fi