### PR TITLE
fix: create root .tmp directory on init for data export

### DIFF
--- a/back/loaders/initFile.ts
+++ b/back/loaders/initFile.ts
@@ -20,6 +20,7 @@ const uploadPath = path.join(dataPath, 'upload/');
 const bakPath = path.join(dataPath, 'bak/');
 const samplePath = path.join(rootPath, 'sample/');
 const tmpPath = path.join(logPath, '.tmp/');
+const rootTmpPath = path.join(rootPath, '.tmp/');
 const confFile = path.join(configPath, 'config.sh');
 const sampleConfigFile = path.join(samplePath, 'config.sample.sh');
 const sampleTaskShellFile = path.join(samplePath, 'task.sample.sh');
@@ -44,6 +45,7 @@ const directories = [
   preloadPath,
   logPath,
   tmpPath,
+  rootTmpPath,
   uploadPath,
   sshPath,
   bakPath,


### PR DESCRIPTION
The data export feature (system backup) writes data.tgz to `config.tmpPath` which resolves to `<rootPath>/.tmp/`. However, `initFile.ts` only created `<dataPath>/log/.tmp/` (used for crontab list temp files), never the root-level `.tmp/` directory.

In Docker deployments, `shell/share.sh`'s `fix_config()` creates `$dir_root/.tmp` during shell initialization, but local/non-Docker deployments that start the Node service directly skip the shell init, causing a 404 ENOENT error when attempting to export/backup data.

Add `rootTmpPath` (`<rootPath>/.tmp/`) to the directories array in `initFile.ts` so it is created during Node service startup regardless of deployment method.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:

