### PR TITLE
fix: 修复鉴权绕过修复中的两个 bug

### DIFF
--- a/back/loaders/express.ts
+++ b/back/loaders/express.ts
@@ -21,18 +21,17 @@ export default ({ app }: { app: Application }) => {
   
   // Security: Path normalization middleware to prevent case variation attacks
   app.use((req, res, next) => {
-    const originalPath = req.path;
-    const normalizedPath = originalPath.toLowerCase();
-    
-    // Block requests with case variations on protected paths
-    if (originalPath !== normalizedPath && 
-        (normalizedPath.startsWith('/api/') || normalizedPath.startsWith('/open/'))) {
+    // Only check the API/OPEN prefix for case variations, not the entire path.
+    // This blocks /API/..., /Api/..., /OPEN/..., /Open/... bypass attempts
+    // while allowing legitimate mixed-case paths like /api/scripts/MyScript.js
+    const pathLower = req.path.toLowerCase();
+    if ((pathLower.startsWith('/api/') && !req.path.startsWith('/api/')) ||
+        (pathLower.startsWith('/open/') && !req.path.startsWith('/open/'))) {
       return res.status(400).json({
         code: 400,
-        message: 'Invalid path format'
+        message: 'Invalid path format',
       });
     }
-    
     next();
   });
   
@@ -126,7 +125,7 @@ export default ({ app }: { app: Application }) => {
         '/api/user/notification/init',
         '/open/user/init',
         '/open/user/notification/init',
-      ].includes(req.path)
+      ].includes(pathLower)
     ) {
       return next();
     }


### PR DESCRIPTION
1. 路径规范化中间件只检查 API/OPEN 前缀大小写而非整个路径 避免误拦截 /api/scripts/MyScript.js 等含大写的合法请求
2. init 中间件改用 pathLower 进行比较，补全防御深度

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information