### PR TITLE
修复删除定时任务后 crontab.list 残留导致订阅更新无法重新注册

### DIFF
--- a/back/schedule/delCron.ts
+++ b/back/schedule/delCron.ts
@@ -13,7 +13,20 @@ const delCron = (
         '[schedule][取消定时任务] 任务ID: %s',
         id,
       );
-      scheduleStacks.get(id)?.forEach(x => x.cancel());
+      // 过滤掉 nodeSchedule.scheduleJob() 对无效表达式返回的 null，
+      // 否则对 null 调 cancel() 会让整个取消流程抛出 UNKNOWN 错误，
+      // 进而导致 HTTP 端的 remove() 跳过 setCrontab()，造成 crontab.list 残留。
+      scheduleStacks.get(id)?.filter((x) => x != null).forEach((x) => {
+        try {
+          x.cancel();
+        } catch (error: any) {
+          Logger.warn(
+            '[schedule][取消任务失败] 任务ID: %s, 错误: %s',
+            id,
+            error?.message || error,
+          );
+        }
+      });
       scheduleStacks.delete(id);
     }
   }

--- a/back/services/cron.ts
+++ b/back/services/cron.ts
@@ -106,15 +106,24 @@ export default class CronService {
     }
 
     if (this.shouldUseCronClient(doc)) {
-      await cronClient.addCron([
-        {
-          name: doc.name || '',
-          id: String(doc.id),
-          schedule: doc.schedule!,
-          command: this.makeCommand(doc),
-          extra_schedules: doc.extra_schedules || [],
-        },
-      ]);
+      try {
+        await cronClient.addCron([
+          {
+            name: doc.name || '',
+            id: String(doc.id),
+            schedule: doc.schedule!,
+            command: this.makeCommand(doc),
+            extra_schedules: doc.extra_schedules || [],
+          },
+        ]);
+      } catch (error: any) {
+        // 调度器注册为尽力而为，失败时不阻断 crontab.list 与系统 crontab 的同步，
+        // 调度器重启后会重新注册（见 autosave_crontab）
+        this.logger.warn(
+          '[crontab] Failed to register cron job in scheduler:',
+          error?.message || error,
+        );
+      }
     }
 
     await this.setCrontab();
@@ -136,18 +145,32 @@ export default class CronService {
       return newDoc;
     }
 
-    await cronClient.delCron([String(newDoc.id)]);
+    try {
+      await cronClient.delCron([String(newDoc.id)]);
+    } catch (error: any) {
+      this.logger.warn(
+        '[crontab] Failed to unregister cron job in scheduler:',
+        error?.message || error,
+      );
+    }
 
     if (this.shouldUseCronClient(newDoc)) {
-      await cronClient.addCron([
-        {
-          name: doc.name || '',
-          id: String(newDoc.id),
-          schedule: newDoc.schedule!,
-          command: this.makeCommand(newDoc),
-          extra_schedules: newDoc.extra_schedules || [],
-        },
-      ]);
+      try {
+        await cronClient.addCron([
+          {
+            name: doc.name || '',
+            id: String(newDoc.id),
+            schedule: newDoc.schedule!,
+            command: this.makeCommand(newDoc),
+            extra_schedules: newDoc.extra_schedules || [],
+          },
+        ]);
+      } catch (error: any) {
+        this.logger.warn(
+          '[crontab] Failed to register cron job in scheduler:',
+          error?.message || error,
+        );
+      }
     }
 
     await this.setCrontab();
@@ -240,7 +263,14 @@ export default class CronService {
 
   public async remove(ids: number[]) {
     await CrontabModel.destroy({ where: { id: ids } });
-    await cronClient.delCron(ids.map(String));
+    try {
+      await cronClient.delCron(ids.map(String));
+    } catch (error: any) {
+      this.logger.warn(
+        '[crontab] Failed to unregister cron job in scheduler:',
+        error?.message || error,
+      );
+    }
     await this.setCrontab();
   }
 
@@ -665,7 +695,14 @@ export default class CronService {
 
   public async disabled(ids: number[]) {
     await CrontabModel.update({ isDisabled: 1 }, { where: { id: ids } });
-    await cronClient.delCron(ids.map(String));
+    try {
+      await cronClient.delCron(ids.map(String));
+    } catch (error: any) {
+      this.logger.warn(
+        '[crontab] Failed to unregister cron job in scheduler:',
+        error?.message || error,
+      );
+    }
     await this.setCrontab();
   }
 
@@ -686,7 +723,14 @@ export default class CronService {
       return;
     }
 
-    await cronClient.addCron(crons);
+    try {
+      await cronClient.addCron(crons);
+    } catch (error: any) {
+      this.logger.warn(
+        '[crontab] Failed to register cron job in scheduler:',
+        error?.message || error,
+      );
+    }
     await this.setCrontab();
   }
 
@@ -864,8 +908,19 @@ export default class CronService {
       await writeFileWithLock(config.crontabFile, '');
       return;
     }
-    await cronClient.addCron(regularCrons);
-    this.setCrontab(tabs);
+
+    // 先同步 crontab.list 与系统 crontab，确保其始终反映数据库真实状态。
+    // gRPC 调度注册为尽力而为：失败时不阻断文件同步，调度器重启后会重新注册。
+    // 这避免了因调度器短暂不可用导致 crontab.list 与数据库脱节（订阅更新误判任务已存在）。
+    await this.setCrontab(tabs);
+    try {
+      await cronClient.addCron(regularCrons);
+    } catch (error: any) {
+      this.logger.warn(
+        '[crontab] Failed to register cron job in scheduler:',
+        error?.message || error,
+      );
+    }
   }
 
   public async bootTask() {


### PR DESCRIPTION
## 问题

前端批量删除由订阅注册的定时任务后，再次"更新订阅"时，脚本不会被重新注册。

## 根因（两处缺陷叠加）

### 1. `back/schedule/delCron.ts` — null job 导致 gRPC handler 崩溃

`nodeSchedule.scheduleJob()` 对无效 cron 表达式（如 `0 * /6 * * *`，`* /6` 中间有空格）会返回 `null`，原代码原样存入 `scheduleStacks` 数组。

`delCron` 取消时对 null 调 `cancel()`：

```ts
scheduleStacks.get(id)?.forEach(x => x.cancel());
//                                       ↑ null.cancel() 抛错
```

→ gRPC handler 抛出 `UNKNOWN` 错误，剩余任务取消流程中断。

### 2. `back/services/cron.ts` — gRPC 错误跳过 `setCrontab()`

`remove()` / `create()` / `update()` / `disabled()` / `enabled()` / `autosave_crontab()` 中，gRPC `delCron`/`addCron` 在 `setCrontab()` 之前调用，一旦 gRPC 抛错就跳过文件同步：

```ts
public async remove(ids: number[]) {
    await CrontabModel.destroy({ where: { id: ids } });   // DB 已删
    await cronClient.delCron(ids.map(String));           // ← 抛错
    await this.setCrontab();                             // ← 跳过！crontab.list 残留
}
```

### 完整事件链（线上已复现取证）

1. 前端删除任务 → `CrontabModel.destroy()` 清空 DB ✅
2. `cronClient.delCron()` 发 gRPC → 遇到 null job 崩溃 💥
3. HTTP 端 `remove()` 抛错 → `setCrontab()` 被跳过
4. `crontab.list` 残留 ID=88~97 等 10 条幽灵记录
5. `gen_list_repo()` 读 `crontab.list` → 误判脚本"已存在"
6. `diff_cron()` 输出 `add.list` 为空 → 不注册新任务 → 前端永远看不到脚本

## 修复

1. **`back/schedule/delCron.ts`**：过滤 null job 并对每个 `cancel()` 加 try/catch 容错，保证部分失败不中断整个取消流程。

2. **`back/services/cron.ts`**：将 `create`/`update`/`remove`/`disabled`/`enabled`/`autosave_crontab` 中的 gRPC 调用改为 try/catch 尽力而为，保证 `setCrontab()` 总是执行；`autosave_crontab` 额外将 `setCrontab` 提前到 `addCron` 之前，避免启动/gRPC 重启时文件不同步或启动崩溃。

## 验证

线上 Docker 容器（`whyour/qinglong:2.21.0-debian`）已复现并验证修复：

| 步骤 | 修复前 | 修复后 |
|---|---|---|
| 删除 my-script 10 个任务 | 报错 `Cannot read properties of null`，crontab.list 残留 10 条 | 无报错，crontab.list 干净（12 行）|
| 再次更新订阅 | "拉取成功" 但无"检测到新任务"，脚本不注册 | "检测到 10 个新任务"，全部添加成功 |

## 兼容性

- gRPC 内存调度自愈：`autosave_crontab` 在 gRPC worker 重启时重新注册所有任务；本修复不改变此行为。
- 错误日志：所有 gRPC 失败现在会写 `warn` 日志（`[crontab] Failed to ...`），便于排障而非静默失败。

## 相关 issue

- `#2422`（自动更新订阅时重复添加任务）很可能是同一根因的另一面（`create()` 中 gRPC 抛错 → `setCrontab` 跳过 → 任务未写入文件 → 下次更新误判不存在 → 重复添加）。